### PR TITLE
Add SonarCloud integration

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,22 @@
+name: SonarCloud
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  sonar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v6
+      - run: ./gradlew test jacocoTestReport sonar
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,6 +17,8 @@ jobs:
           distribution: temurin
           java-version: '17'
       - uses: gradle/actions/setup-gradle@v6
-      - run: ./gradlew test jacocoTestReport sonar
+      - run: ./gradlew test jacocoTestReport
+      - if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        run: ./gradlew sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=BitWeb_montonio-java-sdk&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=BitWeb_montonio-java-sdk)
+
 # Montonio Java SDK
 
 A type-safe Java client for the [Montonio](https://montonio.com) payment gateway REST API (V2 + Stargate). Covers payment order lifecycle, payment method discovery, and JWT webhook/return validation.

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 sonar {
     properties {
         property "sonar.projectKey", "BitWeb_montonio-java-sdk"
-        property "sonar.organization", "bitweb_oss"
+        property "sonar.organization", "bitweb-oss"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.coverage.jacoco.xmlReportPaths",
                 "${layout.buildDirectory.get()}/reports/jacoco/test/jacocoTestReport.xml"

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
     id "org.owasp.dependencycheck" version "12.2.0"
     id "io.freefair.lombok" version "9.2.0"
     id "io.github.gradle-nexus.publish-plugin" version "2.0.0"
+    id "org.sonarqube" version "7.2.3.7755"
 }
 
 group 'ee.bitweb'
@@ -34,4 +35,14 @@ dependencies {
     testImplementation platform('org.junit:junit-bom:5.14.3')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+sonar {
+    properties {
+        property "sonar.projectKey", "BitWeb_montonio-java-sdk"
+        property "sonar.organization", "bitweb_oss"
+        property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.coverage.jacoco.xmlReportPaths",
+                "${layout.buildDirectory.get()}/reports/jacoco/test/jacocoTestReport.xml"
+    }
 }

--- a/test.gradle
+++ b/test.gradle
@@ -2,6 +2,13 @@ apply plugin: 'jacoco'
 
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    reports {
+        xml.required = true
+    }
 }
 
 tasks.register('unitTest', Test) {


### PR DESCRIPTION
## Summary
- Add `org.sonarqube` Gradle plugin (v7.2.3.7755) with SonarCloud properties (`projectKey`, `organization`, `host.url`, JaCoCo report path)
- Create dedicated GitHub Actions workflow that runs `test → jacocoTestReport → sonar` on PRs and pushes to `main`
- Wire `jacocoTestReport` to produce XML and run automatically after `test`
- Add SonarCloud quality gate badge to README

## Manual steps required after merge
- [ ] Register the repository on [SonarCloud](https://sonarcloud.io) under the `bitweb_oss` organization
- [ ] Install the SonarCloud GitHub App on the BitWeb org (if not already installed)
- [ ] Add `SONAR_TOKEN` as a repository secret (GitHub Settings → Secrets → Actions)
- [ ] Verify PR decoration (inline comments, quality gate status check) is working

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Configured automated code coverage reporting, finalised on each test execution.

* **Chores**
  * Integrated SonarCloud code quality analysis into the continuous integration pipeline.
  * Set up GitHub Actions workflow to run quality checks on pull requests and main branch pushes.

* **Documentation**
  * Added SonarCloud quality status badge to the project README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->