### PR TITLE
Add Dependabot configuration for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to automatically monitor and update dependencies
- Configure two ecosystems: **Gradle** (Java dependencies) and **GitHub Actions** (workflow action versions)
- Set weekly update schedule with `dependencies` label for Gradle and `dependencies` + `ci` labels for Actions
- Group minor/patch Gradle updates and all Actions updates to minimize PR noise

Closes #7

## Test plan
- [ ] Verify Dependabot picks up the configuration on next scheduled run
- [ ] Confirm PRs are opened with correct labels and grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated dependency management configuration for Gradle and GitHub Actions updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->